### PR TITLE
[Fix] 생성친구 DTO 수정 및 기념일 필드 생성

### DIFF
--- a/favor/src/main/java/com/favor/favor/anniversary/Anniversary.java
+++ b/favor/src/main/java/com/favor/favor/anniversary/Anniversary.java
@@ -7,6 +7,7 @@ import lombok.*;
 import javax.persistence.*;
 import javax.transaction.Transactional;
 import java.time.LocalDate;
+import java.util.List;
 
 @Entity
 @Getter
@@ -33,6 +34,11 @@ public class Anniversary extends TimeStamped {
     @JoinColumn(name = "user_user_no")
     private User user;
 
+    @ElementCollection
+    private List<Long> friendNoList;
+    public void setFriendNoList(List<Long> friendNoList){
+        this.friendNoList = friendNoList;
+    }
 
 
 }

--- a/favor/src/main/java/com/favor/favor/anniversary/Anniversary.java
+++ b/favor/src/main/java/com/favor/favor/anniversary/Anniversary.java
@@ -7,6 +7,7 @@ import lombok.*;
 import javax.persistence.*;
 import javax.transaction.Transactional;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity

--- a/favor/src/main/java/com/favor/favor/anniversary/AnniversaryController.java
+++ b/favor/src/main/java/com/favor/favor/anniversary/AnniversaryController.java
@@ -73,7 +73,7 @@ public class AnniversaryController {
             @PathVariable Long anniversaryNo){
 
         anniversaryService.isExistingAnniversaryNo(anniversaryNo);
-        Anniversary anniversary = anniversaryService.findAnniversaryByanniversaryNo(anniversaryNo);
+        Anniversary anniversary = anniversaryService.findAnniversaryByAnniversaryNo(anniversaryNo);
         AnniversaryResponseDto dto = anniversaryService.returnDto(anniversary);
 
         return ResponseEntity.status(200)
@@ -105,7 +105,7 @@ public class AnniversaryController {
 
         anniversaryService.isExistingAnniversaryNo(anniversaryNo);
 
-        Anniversary anniversary = anniversaryService.findAnniversaryByanniversaryNo(anniversaryNo);
+        Anniversary anniversary = anniversaryService.findAnniversaryByAnniversaryNo(anniversaryNo);
         anniversaryService.updateAnniversary(anniversaryUpdateRequestDto, anniversary);
         AnniversaryResponseDto dto = anniversaryService.returnDto(anniversary);
 
@@ -137,7 +137,7 @@ public class AnniversaryController {
 
         anniversaryService.isExistingAnniversaryNo(anniversaryNo);
 
-        Anniversary anniversary = anniversaryService.findAnniversaryByanniversaryNo(anniversaryNo);
+        Anniversary anniversary = anniversaryService.findAnniversaryByAnniversaryNo(anniversaryNo);
         AnniversaryResponseDto dto = anniversaryService.returnDto(anniversary);
 
         anniversaryService.deleteAnniversary(anniversaryNo);

--- a/favor/src/main/java/com/favor/favor/anniversary/AnniversaryController.java
+++ b/favor/src/main/java/com/favor/favor/anniversary/AnniversaryController.java
@@ -98,15 +98,15 @@ public class AnniversaryController {
     })
     @ResponseStatus(HttpStatus.OK)
     @Transactional
-    @PatchMapping("/{anniversaryrNo}")
+    @PatchMapping("/{anniversaryNo}")
     public ResponseEntity<DefaultResponseDto<Object>> updateAnniversary(
             @RequestBody AnniversaryUpdateRequestDto anniversaryUpdateRequestDto,
-            @PathVariable Long anniversaryrNo){
+            @PathVariable Long anniversaryNo){
 
-        anniversaryService.isExistingAnniversaryNo(anniversaryrNo);
+        anniversaryService.isExistingAnniversaryNo(anniversaryNo);
 
-        Anniversary anniversary = anniversaryService.findAnniversaryByanniversaryNo(anniversaryrNo);
-        anniversaryService.updateAnniversary(anniversaryUpdateRequestDto, anniversaryrNo);
+        Anniversary anniversary = anniversaryService.findAnniversaryByanniversaryNo(anniversaryNo);
+        anniversaryService.updateAnniversary(anniversaryUpdateRequestDto, anniversary);
         AnniversaryResponseDto dto = anniversaryService.returnDto(anniversary);
 
         return ResponseEntity.status(200)

--- a/favor/src/main/java/com/favor/favor/anniversary/AnniversaryRequestDto.java
+++ b/favor/src/main/java/com/favor/favor/anniversary/AnniversaryRequestDto.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import javax.transaction.Transactional;
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -19,11 +20,15 @@ public class AnniversaryRequestDto {
     @ApiModelProperty(position = 2, required = true, value = "날짜", example = "1996-02-29")
     private String anniversaryDate;
 
+    @ApiModelProperty(position = 3, required = true, value = "관련친구목록", example = "[\n    1\n  ]")
+    private List<Long> friendNoList;
+
     @Transactional
     public Anniversary toEntity(User user, LocalDate localDate){
         return Anniversary.builder()
                 .anniversaryTitle(anniversaryTitle)
                 .anniversaryDate(localDate)
+                .friendNoList(friendNoList)
                 .isPinned(false)
                 .user(user)
                 .build();

--- a/favor/src/main/java/com/favor/favor/anniversary/AnniversaryResponseDto.java
+++ b/favor/src/main/java/com/favor/favor/anniversary/AnniversaryResponseDto.java
@@ -5,10 +5,10 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
-@Builder
 public class AnniversaryResponseDto {
     private Long anniversaryNo;
     private String anniversaryTitle;

--- a/favor/src/main/java/com/favor/favor/anniversary/AnniversaryService.java
+++ b/favor/src/main/java/com/favor/favor/anniversary/AnniversaryService.java
@@ -25,6 +25,7 @@ public class AnniversaryService {
     private final UserRepository userRepository;
     private final FriendRepository friendRepository;
 
+    @Transactional
     public Anniversary createAnniversary(AnniversaryRequestDto anniversaryRequestDto, Long userNo){
         User user = findUserByUserNo(userNo);
         LocalDate localDate = returnLocalDate(anniversaryRequestDto.getAnniversaryDate());

--- a/favor/src/main/java/com/favor/favor/anniversary/AnniversaryService.java
+++ b/favor/src/main/java/com/favor/favor/anniversary/AnniversaryService.java
@@ -41,11 +41,9 @@ public class AnniversaryService {
             List<Long> anniversaryNoList = friend.getAnniversaryNoList();
 
             boolean flag = true;
-            for(Long no : friend.getAnniversaryNoList()){
-                if (no == anniversaryNo) {
-                    flag = false;
-                    break;
-                }
+            if (anniversaryNoList.contains(anniversaryNo)) {
+                flag = false;
+                break;
             }
             if(flag) anniversaryNoList.add(anniversaryNo);
 
@@ -71,13 +69,22 @@ public class AnniversaryService {
         anniversary.setAnniversaryDate(localDate);
         anniversary.setIsPinned(dto.getIsPinned());
 
+
+        Long anniversaryNo = anniversary.getAnniversaryNo();
         List<Long> existingFriendNoList = anniversary.getFriendNoList();
         List<Long> updatedFriendNoList = dto.getFriendNoList();
 
         for (Long friendNo : existingFriendNoList) {
             if (!updatedFriendNoList.contains(friendNo)) {
                 Friend friend = findFriendByFriendNo(friendNo);
-                friend.getAnniversaryNoList().remove(anniversary.getAnniversaryNo());
+                friend.getAnniversaryNoList().remove(anniversaryNo);
+                friendRepository.save(friend);
+            }
+        }
+        for(Long friendNo : updatedFriendNoList){
+            Friend friend = findFriendByFriendNo(friendNo);
+            if(!friend.getAnniversaryNoList().contains(anniversaryNo)){
+                friend.getAnniversaryNoList().add(anniversaryNo);
                 friendRepository.save(friend);
             }
         }
@@ -89,6 +96,14 @@ public class AnniversaryService {
     }
 
     public void deleteAnniversary(Long anniversaryNo){
+        List<Friend> friendList = findAnniversaryByAnniversaryNo(anniversaryNo).getUser().getFriendList();
+        for(Friend friend : friendList){
+            if(friend.getAnniversaryNoList().contains(anniversaryNo)){
+                friend.getAnniversaryNoList().remove(anniversaryNo);
+                friendRepository.save(friend);
+            }
+        }
+
         anniversaryRepository.deleteByAnniversaryNo(anniversaryNo);
     }
 
@@ -113,7 +128,7 @@ public class AnniversaryService {
         }
         return user;
     }
-    public Anniversary findAnniversaryByanniversaryNo(Long anniversaryNo){
+    public Anniversary findAnniversaryByAnniversaryNo(Long anniversaryNo){
         Anniversary anniversary = null;
         try{
             anniversary = anniversaryRepository.findAnniversaryByAnniversaryNo(anniversaryNo).orElseThrow(

--- a/favor/src/main/java/com/favor/favor/anniversary/AnniversaryUpdateRequestDto.java
+++ b/favor/src/main/java/com/favor/favor/anniversary/AnniversaryUpdateRequestDto.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 
 @Getter
 @NoArgsConstructor
@@ -17,6 +19,9 @@ public class AnniversaryUpdateRequestDto {
     @ApiModelProperty(position = 2, required = true, value = "날짜", example = "1996-02-29")
     private String anniversaryDate;
 
-    @ApiModelProperty(position = 3, required = true, value = "핀 여부", example = "false")
+    @ApiModelProperty(position = 3, required = true, value = "관련친구목록", example = "[\n    1\n  ]")
+    private List<Long> friendNoList;
+
+    @ApiModelProperty(position = 4, required = true, value = "핀 여부", example = "false")
     private Boolean isPinned;
 }

--- a/favor/src/main/java/com/favor/favor/friend/Friend.java
+++ b/favor/src/main/java/com/favor/favor/friend/Friend.java
@@ -1,6 +1,7 @@
 package com.favor.favor.friend;
 
 
+import com.favor.favor.common.enums.Favor;
 import lombok.*;
 
 import com.favor.favor.common.TimeStamped;
@@ -48,6 +49,14 @@ public class Friend extends TimeStamped {
     @Builder.Default
     @ElementCollection
     private List<Integer> favorList = new ArrayList<>();
+    public void setFavorList(List<Favor> favorList){
+        ArrayList<Integer> favorTypeList = new ArrayList<>();
+        for(Favor favor : favorList){
+            favorTypeList.add(favor.getType());
+        }
+        this.favorList = favorTypeList;
+    }
+
     private Boolean isUser;
 
     private Long friendUserNo;
@@ -57,5 +66,12 @@ public class Friend extends TimeStamped {
     private List<Long> giftNoList = new ArrayList<>();
     public void setGiftNoList(List<Long> giftNoList){
         this.giftNoList = giftNoList;
+    }
+
+    @Builder.Default
+    @ElementCollection
+    private List<Long> anniversaryNoList = new ArrayList<>();
+    public void setAnniversaryNoList(List<Long> anniversaryNoList){
+        this.anniversaryNoList = anniversaryNoList;
     }
 }

--- a/favor/src/main/java/com/favor/favor/friend/FriendResponseDto.java
+++ b/favor/src/main/java/com/favor/favor/friend/FriendResponseDto.java
@@ -27,7 +27,7 @@ public class FriendResponseDto {
     private Long friendUserNo;
 
 
-    private List<AnniversaryResponseDto> anniversaryList;
+    private List<Long> anniversaryNoList;
     private Long userNo;
 
     @Builder
@@ -39,7 +39,7 @@ public class FriendResponseDto {
         this.reminderList = new ArrayList<>();
         this.giftList = new ArrayList<>();
         this.favorList = new ArrayList<>();
-        this.anniversaryList = new ArrayList<>();
+        this.anniversaryNoList = new ArrayList<>();
         this.friendUserNo = friend.getFriendUserNo();
         this.userNo = friend.getUser().getUserNo();
     }
@@ -49,7 +49,7 @@ public class FriendResponseDto {
                              List<ReminderResponseDto> reminderList,
                              List<GiftResponseDto> giftList,
                              List<Favor> favorList,
-                             List<AnniversaryResponseDto> anniversaryList
+                             List<Long> anniversaryNoList
     ){
         this.isUser = friend.getIsUser();
         this.friendNo = friend.getFriendNo();
@@ -58,7 +58,7 @@ public class FriendResponseDto {
         this.reminderList = reminderList;
         this.giftList = giftList;
         this.favorList = favorList;
-        this.anniversaryList = anniversaryList;
+        this.anniversaryNoList = anniversaryNoList;
         this.friendUserNo = friend.getFriendUserNo();
         this.userNo = friend.getUser().getUserNo();
     }

--- a/favor/src/main/java/com/favor/favor/friend/FriendService.java
+++ b/favor/src/main/java/com/favor/favor/friend/FriendService.java
@@ -161,12 +161,12 @@ public class FriendService {
         for(Integer favorType : user.getFavorList()){
             favorList.add(Favor.valueOf(favorType));
         }
-        List<AnniversaryResponseDto> anniversaryDtoList = new ArrayList<>();
+        List<Long> anniversaryNoList = new ArrayList<>();
         for(Anniversary a : user.getAnniversaryList()){
-            anniversaryDtoList.add(new AnniversaryResponseDto(a));
+            anniversaryNoList.add(a.getAnniversaryNo());
         }
 
-        return new FriendResponseDto(friend, reminderDtoList, giftDtoList, favorList, anniversaryDtoList);
+        return new FriendResponseDto(friend, reminderDtoList, giftDtoList, favorList, anniversaryNoList);
     }
     public FriendResponseDto returnDtoForFriend(Friend friend){
         List<ReminderResponseDto> reminderDtoList = new ArrayList<>();
@@ -183,9 +183,12 @@ public class FriendService {
         for(Integer favorType : friend.getFavorList()){
             favorList.add(Favor.valueOf(favorType));
         }
-        List<AnniversaryResponseDto> anniversaryList = new ArrayList<>();
+        List<Long> anniversaryNoList = new ArrayList<>();
+        for(Long a : friend.getAnniversaryNoList()){
+            anniversaryNoList.add(a);
+        }
 
-        return new FriendResponseDto(friend, reminderDtoList, giftDtoList, favorList, anniversaryList);
+        return new FriendResponseDto(friend, reminderDtoList, giftDtoList, favorList, anniversaryNoList);
     }
 
 

--- a/favor/src/main/java/com/favor/favor/friend/FriendService.java
+++ b/favor/src/main/java/com/favor/favor/friend/FriendService.java
@@ -68,6 +68,8 @@ public class FriendService {
 
         friend.setFriendName(friendUpdateRequestDto.getFriendName());
         friend.setFriendMemo(friendUpdateRequestDto.getFriendMemo());
+        friend.setFavorList(friendUpdateRequestDto.getFavorList());
+        friend.setAnniversaryNoList(friendUpdateRequestDto.getAnniversaryNoList());
         save(friend);
     }
 

--- a/favor/src/main/java/com/favor/favor/friend/FriendService.java
+++ b/favor/src/main/java/com/favor/favor/friend/FriendService.java
@@ -69,7 +69,6 @@ public class FriendService {
         friend.setFriendName(friendUpdateRequestDto.getFriendName());
         friend.setFriendMemo(friendUpdateRequestDto.getFriendMemo());
         friend.setFavorList(friendUpdateRequestDto.getFavorList());
-        friend.setAnniversaryNoList(friendUpdateRequestDto.getAnniversaryNoList());
         save(friend);
     }
 

--- a/favor/src/main/java/com/favor/favor/friend/account/FriendUserRequestDto.java
+++ b/favor/src/main/java/com/favor/favor/friend/account/FriendUserRequestDto.java
@@ -15,17 +15,13 @@ import javax.transaction.Transactional;
 public class FriendUserRequestDto {
     @ApiModelProperty(position = 1, required = true, dataType = "Long", value = "회원친구번호", example = "1")
     private Long friendUserNo;
-
-    @ApiModelProperty(position = 2, required = false, dataType = "String", value = "회원친구메모", example = "메모")
-    private String userFriendMemo;
-
     @Transactional
     public Friend toEntity(User user, User userFriend){
         return Friend.builder()
                 .isUser(true)
                 .friendUserNo(friendUserNo)
                 .friendName(userFriend.getName())
-                .friendMemo(userFriendMemo)
+                .friendMemo("")
                 .user(user)
                 .build();
     }

--- a/favor/src/main/java/com/favor/favor/friend/noAccount/FriendRequestDto.java
+++ b/favor/src/main/java/com/favor/favor/friend/noAccount/FriendRequestDto.java
@@ -16,15 +16,12 @@ public class FriendRequestDto {
     @ApiModelProperty(position = 1, required = true, value = "친구이름", example = "이름")
     private String friendName;
 
-    @ApiModelProperty(position = 2, required = false, value = "친구메모", example = "메모")
-    private String friendMemo;
-
     @Transactional
     public Friend toEntity(User user){
         return Friend.builder()
                 .isUser(false)
                 .friendName(friendName)
-                .friendMemo(friendMemo)
+                .friendMemo("")
                 .user(user)
                 .build();
     }

--- a/favor/src/main/java/com/favor/favor/friend/noAccount/FriendUpdateRequestDto.java
+++ b/favor/src/main/java/com/favor/favor/friend/noAccount/FriendUpdateRequestDto.java
@@ -21,9 +21,4 @@ public class FriendUpdateRequestDto {
 
     @ApiModelProperty(position = 3, required = false, value = "취향목록", example = "[\n\"심플한\"\n]")
     private List<Favor> favorList;
-
-    @ApiModelProperty(position = 4, required = false, value = "기념일목록", example = "[\n" +
-                                                                                    "    1, 2\n" +
-                                                                                    "  ]")
-    private List<Long> anniversaryNoList;
 }

--- a/favor/src/main/java/com/favor/favor/friend/noAccount/FriendUpdateRequestDto.java
+++ b/favor/src/main/java/com/favor/favor/friend/noAccount/FriendUpdateRequestDto.java
@@ -1,12 +1,13 @@
 package com.favor.favor.friend.noAccount;
 
-import com.favor.favor.friend.Friend;
+import com.favor.favor.anniversary.Anniversary;
+import com.favor.favor.common.enums.Favor;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.transaction.Transactional;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -18,11 +19,11 @@ public class FriendUpdateRequestDto {
     @ApiModelProperty(position = 2, required = false, dataType = "String", value = "친구메모", example = "메모")
     private String friendMemo;
 
-    @Transactional
-    public Friend toEntity(){
-        return Friend.builder()
-                .friendName(friendName)
-                .friendMemo(friendMemo)
-                .build();
-    }
+    @ApiModelProperty(position = 3, required = false, value = "취향목록", example = "[\n\"심플한\"\n]")
+    private List<Favor> favorList;
+
+    @ApiModelProperty(position = 4, required = false, value = "기념일목록", example = "[\n" +
+                                                                                    "    1, 2\n" +
+                                                                                    "  ]")
+    private List<Long> anniversaryNoList;
 }

--- a/favor/src/main/java/com/favor/favor/friend/noAccount/FriendUpdateRequestDto.java
+++ b/favor/src/main/java/com/favor/favor/friend/noAccount/FriendUpdateRequestDto.java
@@ -1,6 +1,5 @@
 package com.favor.favor.friend.noAccount;
 
-import com.favor.favor.anniversary.Anniversary;
 import com.favor.favor.common.enums.Favor;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;

--- a/favor/src/main/java/com/favor/favor/friend/noAccount/FriendUpdateRequestDto.java
+++ b/favor/src/main/java/com/favor/favor/friend/noAccount/FriendUpdateRequestDto.java
@@ -6,8 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
 
+import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/favor/src/main/java/com/favor/favor/gift/Gift.java
+++ b/favor/src/main/java/com/favor/favor/gift/Gift.java
@@ -68,7 +68,7 @@ public class Gift extends TimeStamped {
     @Builder.Default
     @ElementCollection
     private List<Long> friendNoList = new ArrayList<>();
-    public void setFriendNo(List<Long> friendNoList){
+    public void setFriendNoList(List<Long> friendNoList){
         this.friendNoList = friendNoList;
     }
 }


### PR DESCRIPTION
## 📋 이슈 번호
- #40 

## 🛠 구현 사항
-  FriendRequestDto 에서 memo 삭제
- 친구 추가/생성 시 memo에 빈 문자열 등록
- 친구 수정 API에 favorList 수정 메서드 추가

- 친구 수정 API에 anniversaryList 수정 메서드 추가 -> 필요한지 의문이 들어 디스코드에 질문해둔 상태
- 추가적으로 선물과 기념일에서 연관 친구를 삭제해도 친구의 리스트에 선물이나 기념일이 남아있던 버그 수정
- 추가적으로 기념일을 삭제해도 친구의 기념일 목록에서 목록일이 사라지지 않는 버그 수정

## 📚 기타
