### PR TITLE
[Fix] 유저 탈퇴시, 친구 삭제 시 관련 선물 조회 불가 해결

### DIFF
--- a/favor/src/main/java/com/favor/favor/anniversary/Anniversary.java
+++ b/favor/src/main/java/com/favor/favor/anniversary/Anniversary.java
@@ -1,6 +1,7 @@
 package com.favor.favor.anniversary;
 
 import com.favor.favor.common.TimeStamped;
+import com.favor.favor.common.enums.Category;
 import com.favor.favor.user.User;
 import lombok.*;
 
@@ -28,18 +29,16 @@ public class Anniversary extends TimeStamped {
     private LocalDate anniversaryDate;
     public void setAnniversaryDate(LocalDate anniversaryDate){ this.anniversaryDate = anniversaryDate; }
 
+    private Integer category;
+    public void setCategory(Category category){
+        this.category = category.getType();
+    }
+
     private Boolean isPinned;
     public void setIsPinned(Boolean isPinned){ this.isPinned = isPinned; }
 
     @ManyToOne(cascade = CascadeType.REFRESH)
     @JoinColumn(name = "user_user_no")
     private User user;
-
-    @ElementCollection
-    private List<Long> friendNoList;
-    public void setFriendNoList(List<Long> friendNoList){
-        this.friendNoList = friendNoList;
-    }
-
 
 }

--- a/favor/src/main/java/com/favor/favor/anniversary/AnniversaryRequestDto.java
+++ b/favor/src/main/java/com/favor/favor/anniversary/AnniversaryRequestDto.java
@@ -1,5 +1,6 @@
 package com.favor.favor.anniversary;
 
+import com.favor.favor.common.enums.Category;
 import com.favor.favor.user.User;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
@@ -8,7 +9,6 @@ import lombok.NoArgsConstructor;
 
 import javax.transaction.Transactional;
 import java.time.LocalDate;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -20,15 +20,15 @@ public class AnniversaryRequestDto {
     @ApiModelProperty(position = 2, required = true, value = "날짜", example = "1996-02-29")
     private String anniversaryDate;
 
-    @ApiModelProperty(position = 3, required = true, value = "관련친구목록", example = "[\n    1\n  ]")
-    private List<Long> friendNoList;
+    @ApiModelProperty(position = 3, required = true, value = "종류", example = "생일")
+    private Category category;
 
     @Transactional
     public Anniversary toEntity(User user, LocalDate localDate){
         return Anniversary.builder()
                 .anniversaryTitle(anniversaryTitle)
                 .anniversaryDate(localDate)
-                .friendNoList(friendNoList)
+                .category(category.getType())
                 .isPinned(false)
                 .user(user)
                 .build();

--- a/favor/src/main/java/com/favor/favor/anniversary/AnniversaryService.java
+++ b/favor/src/main/java/com/favor/favor/anniversary/AnniversaryService.java
@@ -30,7 +30,6 @@ public class AnniversaryService {
         User user = findUserByUserNo(userNo);
         LocalDate localDate = returnLocalDate(anniversaryRequestDto.getAnniversaryDate());
         Anniversary anniversary = anniversaryRepository.save(anniversaryRequestDto.toEntity(user, localDate));
-        addAnniversaryNo(anniversary.getAnniversaryNo(), anniversary.getFriendNoList());
         return anniversaryRepository.save(anniversary);
     }
 
@@ -67,30 +66,8 @@ public class AnniversaryService {
         anniversary.setAnniversaryTitle(dto.getAnniversaryTitle());
         LocalDate localDate = returnLocalDate(dto.getAnniversaryDate());
         anniversary.setAnniversaryDate(localDate);
+        anniversary.setCategory(dto.getCategory());
         anniversary.setIsPinned(dto.getIsPinned());
-
-
-        Long anniversaryNo = anniversary.getAnniversaryNo();
-        List<Long> existingFriendNoList = anniversary.getFriendNoList();
-        List<Long> updatedFriendNoList = dto.getFriendNoList();
-
-        for (Long friendNo : existingFriendNoList) {
-            if (!updatedFriendNoList.contains(friendNo)) {
-                Friend friend = findFriendByFriendNo(friendNo);
-                friend.getAnniversaryNoList().remove(anniversaryNo);
-                friendRepository.save(friend);
-            }
-        }
-        for(Long friendNo : updatedFriendNoList){
-            Friend friend = findFriendByFriendNo(friendNo);
-            if(!friend.getAnniversaryNoList().contains(anniversaryNo)){
-                friend.getAnniversaryNoList().add(anniversaryNo);
-                friendRepository.save(friend);
-            }
-        }
-
-        anniversary.setFriendNoList(updatedFriendNoList);
-        addAnniversaryNo(anniversary.getAnniversaryNo(), updatedFriendNoList);
 
         anniversaryRepository.save(anniversary);
     }

--- a/favor/src/main/java/com/favor/favor/anniversary/AnniversaryUpdateRequestDto.java
+++ b/favor/src/main/java/com/favor/favor/anniversary/AnniversaryUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.favor.favor.anniversary;
 
+import com.favor.favor.common.enums.Category;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,8 +20,8 @@ public class AnniversaryUpdateRequestDto {
     @ApiModelProperty(position = 2, required = true, value = "날짜", example = "1996-02-29")
     private String anniversaryDate;
 
-    @ApiModelProperty(position = 3, required = true, value = "관련친구목록", example = "[\n    1\n  ]")
-    private List<Long> friendNoList;
+    @ApiModelProperty(position = 3, required = true, value = "종류", example = "생일")
+    private Category category;
 
     @ApiModelProperty(position = 4, required = true, value = "핀 여부", example = "false")
     private Boolean isPinned;

--- a/favor/src/main/java/com/favor/favor/friend/Friend.java
+++ b/favor/src/main/java/com/favor/favor/friend/Friend.java
@@ -36,7 +36,7 @@ public class Friend extends TimeStamped {
     }
 
 
-    @ManyToOne(cascade = CascadeType.REFRESH)
+    @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "user_user_no")
     private User user;
 

--- a/favor/src/main/java/com/favor/favor/friend/FriendService.java
+++ b/favor/src/main/java/com/favor/favor/friend/FriendService.java
@@ -74,6 +74,17 @@ public class FriendService {
 
     @Transactional
     public void deleteFriend(Long friendNo){
+        Friend friend = findFriendByFriendNo(friendNo);
+
+        List<Long> giftNoList = friend.getGiftNoList();
+        for(Long g : giftNoList){
+            Gift gift = findGiftByGiftNo(g);
+            List<Long> friendNoList = gift.getFriendNoList();
+            friendNoList.remove(friendNo);
+            gift.setFriendNoList(friendNoList);
+            giftRepository.save(gift);
+        }
+
         friendRepository.deleteById(friendNo);
     }
 

--- a/favor/src/main/java/com/favor/favor/user/UserService.java
+++ b/favor/src/main/java/com/favor/favor/user/UserService.java
@@ -383,6 +383,7 @@ public class UserService {
             ReminderResponseDto dto = new ReminderResponseDto(r);
             r_List.add(dto);
         }
+
         List<GiftResponseDto> g_List = new ArrayList<>();
         List<Gift> giftList = user.getGiftList();
         for(Gift gift : giftList){

--- a/favor/src/main/resources/application.yml
+++ b/favor/src/main/resources/application.yml
@@ -10,7 +10,6 @@ spring:
     show-sql: 'true'
     hibernate:
       ddl-auto: update
-    open-in-view: 'false'
     properties:
       hibernate:
         format_sql: 'true'


### PR DESCRIPTION
## 📋 이슈 번호
- #44 

## 🛠 구현 사항

| 수정 전 친구 삭제 후 관련 선물 | 수정 전 회원친구 탈퇴 후 관련 선물 |
| --- | --- |
|  ![20230620173617](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/2c3dc5c8-a8bc-42bd-91d8-790b8418c155)| ![20230620173617](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/8d256437-f833-4347-a162-68a096eb91dd) |

<br>

| 수정 후 친구 삭제 후 관련 선물 | 수정 후 회원친구 탈퇴 후 관련 선물 |
| --- | --- |
| ![20230620173917](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/97bacf51-8d13-4995-9190-e74e33986fff) | ![20230620173942](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/9aaa9bf0-9cef-4be7-ab5b-db6bd77f167b) |

- 해당 유저 친구로 갖는 유저 조회 불가 해결
- 해당 유저 친구로 관련된 선물 조회 불가 해결
- 유저 한 명 관련 시 DTO 반환 불가 해결

## 📚 기타
