### PR TITLE
[Fix] 회원 조회 시 친구 정보 최신화되지 않는 문제

### DIFF
--- a/favor/src/main/java/com/favor/favor/friend/FriendResponseDto.java
+++ b/favor/src/main/java/com/favor/favor/friend/FriendResponseDto.java
@@ -3,6 +3,7 @@ package com.favor.favor.friend;
 import com.favor.favor.anniversary.AnniversaryResponseDto;
 import com.favor.favor.common.enums.Favor;
 import com.favor.favor.reminder.ReminderResponseDto;
+import com.favor.favor.user.User;
 import lombok.*;
 
 import java.util.ArrayList;
@@ -39,6 +40,20 @@ public class FriendResponseDto {
         this.receivedGift = 0;
         this.totalGift = 0;
         this.userNo = friend.getFriendUserNo();
+    }
+
+    @Builder
+    public FriendResponseDto(Friend friend, User user){
+        this.friendNo = friend.getFriendNo();
+        this.friendName = user.getUsername();
+        this.friendMemo = friend.getFriendMemo();
+        this.reminderList = new ArrayList<>();
+        this.favorList = new ArrayList<>();
+        this.anniversaryList = new ArrayList<>();
+        this.givenGift = 0;
+        this.receivedGift = 0;
+        this.totalGift = 0;
+        this.userNo = user.getUserNo();
     }
 
     @Builder

--- a/favor/src/main/java/com/favor/favor/user/UserService.java
+++ b/favor/src/main/java/com/favor/favor/user/UserService.java
@@ -182,7 +182,8 @@ public class UserService {
 
         List<FriendResponseDto> f_List = new ArrayList<>();
         for(Friend f : user.getFriendList()){
-            FriendResponseDto dto = new FriendResponseDto(f);
+            User friendUser = findUserByUserNo(userNo);
+            FriendResponseDto dto = new FriendResponseDto(f, friendUser);
             f_List.add(dto);
         }
         return f_List;
@@ -384,6 +385,7 @@ public class UserService {
 
 
     //RETURN
+
     @Transactional
     public UserResponseDto returnUserDto(User user){
 
@@ -395,7 +397,8 @@ public class UserService {
 
         List<FriendResponseDto> f_List = new ArrayList<>();
         for(Friend f : user.getFriendList()){
-            FriendResponseDto dto = new FriendResponseDto(f);
+            User friendUser = findUserByUserNo(f.getFriendUserNo());
+            FriendResponseDto dto = new FriendResponseDto(f, friendUser);
             f_List.add(dto);
         }
 


### PR DESCRIPTION
## 📋 이슈 번호
- #65 close

## 🛠 구현 사항

### 친구의 이름이 페이버->돌자반 으로 바뀐 상황

| 전 | 후 |
| --- | --- |
| 회원 조회(전) | 회원 조회(후) |
| ![20230719195520](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/bb109bcb-585c-4729-af18-94bf99945137) | ![20230719200135](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/ab3132c7-fce8-45fe-b269-2a29441c0d9e) |
| 회원 친구목록(전) | 회원 친구목록(후) |
| ![20230719200544](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/2d5dcca3-d263-4829-a0ce-b13893defe69) | ![20230719200753](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/11b858ca-4286-4671-ad11-223c8a8ab836) |

## 📚 기타
