### PR TITLE
[Fix] 리마인더 리스트 DTO 수정, 친구 nullable 여부 수정

### DIFF
--- a/favor/src/main/java/com/favor/favor/friend/FriendService.java
+++ b/favor/src/main/java/com/favor/favor/friend/FriendService.java
@@ -7,6 +7,7 @@ import com.favor.favor.exception.CustomException;
 import com.favor.favor.gift.Gift;
 import com.favor.favor.gift.GiftRepository;
 import com.favor.favor.gift.GiftSimpleDto;
+import com.favor.favor.photo.UserPhoto;
 import com.favor.favor.reminder.Reminder;
 import org.springframework.transaction.annotation.Transactional;
 import com.favor.favor.reminder.ReminderSimpleDto;
@@ -169,7 +170,14 @@ public class FriendService {
         List<Reminder> reminderList = friendUser.getReminderList();
         List<ReminderSimpleDto> reminderDtoList = new ArrayList<>();
         for(Reminder r : reminderList){
-            reminderDtoList.add(new ReminderSimpleDto(r));
+            Friend reminderFriend = r.getFriend();
+            FriendSimpleDto friendsimpleDto = null;
+            if(reminderFriend != null) {
+                User reminderFriendUser = findUserByUserNo(reminderFriend.getFriendUserNo());
+                UserPhoto photo = reminderFriendUser.getUserProfilePhoto();
+                friendsimpleDto = new FriendSimpleDto(reminderFriend, reminderFriendUser, photo);
+            }
+            reminderDtoList.add(new ReminderSimpleDto(r, friendsimpleDto));
         }
         List<Favor> favorList = new ArrayList<>();
         for(Integer favorType : friendUser.getFavorList()){

--- a/favor/src/main/java/com/favor/favor/reminder/Reminder.java
+++ b/favor/src/main/java/com/favor/favor/reminder/Reminder.java
@@ -50,8 +50,8 @@ public class Reminder {
     @JoinColumn(name = "user_user_no")
     private User user;
 
-    @ManyToOne(cascade = CascadeType.REFRESH, fetch = FetchType.EAGER)
-    @JoinColumn(name = "friend_friend_no")
+    @ManyToOne(cascade = CascadeType.REFRESH, fetch = FetchType.EAGER, optional = true)
+    @JoinColumn(name = "friend_friend_no", nullable = true)
     private Friend friend;
     public void setFriend(Friend friend){
         this.friend = friend;

--- a/favor/src/main/java/com/favor/favor/reminder/ReminderController.java
+++ b/favor/src/main/java/com/favor/favor/reminder/ReminderController.java
@@ -40,18 +40,23 @@ public class ReminderController {
                     message = "SERVER_ERROR")
     })
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/new/{friendNo}")
+    @PostMapping("/new")
     public ResponseEntity<DefaultResponseDto<Object>> createReminder(
             @RequestBody ReminderRequestDto reminderRequestDto,
-            @AuthenticationPrincipal User loginUser,
-            @PathVariable Long friendNo){
+            @AuthenticationPrincipal User loginUser){
 
         Long userNo = loginUser.getUserNo();
 
         reminderService.isExistingUserNo(userNo);
-        reminderService.isExistingFriendNo(friendNo);
-
-        Reminder reminder = reminderService.createReminder(reminderRequestDto, userNo, friendNo);
+        if(reminderRequestDto.getFriendNo() != null){
+            reminderService.isExistingFriendNo(reminderRequestDto.getFriendNo());
+        }
+        Reminder reminder = null;
+        if(reminderRequestDto.getFriendNo() != null){
+            reminder = reminderService.createReminder(reminderRequestDto, userNo, reminderRequestDto.getFriendNo());
+        }else{
+            reminder = reminderService.createReminder(reminderRequestDto, userNo, null);
+        }
         ReminderResponseDto dto = reminderService.returnDto(reminder);
 
         return ResponseEntity.status(201)

--- a/favor/src/main/java/com/favor/favor/reminder/ReminderRequestDto.java
+++ b/favor/src/main/java/com/favor/favor/reminder/ReminderRequestDto.java
@@ -30,6 +30,9 @@ public class ReminderRequestDto {
     @ApiModelProperty(position = 5, required = true, value = "메모", example = "메모")
     private String reminderMemo;
 
+    @ApiModelProperty(position = 5, required = false, value = "친구 식별자", example = "1")
+    private Long friendNo;
+
     public Reminder toEntity(User user, Friend friend, LocalDate localDate, LocalDateTime localDateTime){
         return Reminder.builder()
                 .reminderTitle(reminderTitle)

--- a/favor/src/main/java/com/favor/favor/reminder/ReminderService.java
+++ b/favor/src/main/java/com/favor/favor/reminder/ReminderService.java
@@ -34,7 +34,10 @@ public class ReminderService {
     @Transactional
     public Reminder createReminder(ReminderRequestDto reminderRequestDto, Long userNo, Long friendNo){
         User user = findUserByUserNo(userNo);
-        Friend friend = findFriendByFriendNo(friendNo);
+        Friend friend = null;
+        if (friendNo != null) {
+            friend = findFriendByFriendNo(friendNo);
+        }
         LocalDate localDate = returnLocalDate(reminderRequestDto.getReminderDate());
         LocalDateTime localDateTime = returnLocalDateTime(reminderRequestDto.getAlarmTime());
         return reminderRepository.save(reminderRequestDto.toEntity(user, friend, localDate, localDateTime));
@@ -153,9 +156,12 @@ public class ReminderService {
 
     public ReminderResponseDto returnDto(Reminder reminder){
         Friend friend = reminder.getFriend();
-        User friendUser = findUserByUserNo(friend.getFriendUserNo());
-        UserPhoto photo = friendUser.getUserProfilePhoto();
-        FriendSimpleDto dto = new FriendSimpleDto(friend, friendUser, photo);
+        FriendSimpleDto dto = null;
+        if(friend != null) {
+            User friendUser = findUserByUserNo(friend.getFriendUserNo());
+            UserPhoto photo = friendUser.getUserProfilePhoto();
+            dto = new FriendSimpleDto(friend, friendUser, photo);
+        }
         return new ReminderResponseDto(reminder, dto);
     }
     public LocalDate returnLocalDate(String dateString){

--- a/favor/src/main/java/com/favor/favor/reminder/ReminderService.java
+++ b/favor/src/main/java/com/favor/favor/reminder/ReminderService.java
@@ -83,7 +83,14 @@ public class ReminderService {
     public List<ReminderSimpleDto> readAll(){
         List<ReminderSimpleDto> r_List = new ArrayList<>();
         for(Reminder r : reminderRepository.findAll()){
-            ReminderSimpleDto dto = new ReminderSimpleDto(r);
+            Friend friend = r.getFriend();
+            FriendSimpleDto friendsimpleDto = null;
+            if(friend != null) {
+                User friendUser = findUserByUserNo(friend.getFriendUserNo());
+                UserPhoto photo = friendUser.getUserProfilePhoto();
+                friendsimpleDto = new FriendSimpleDto(friend, friendUser, photo);
+            }
+            ReminderSimpleDto dto = new ReminderSimpleDto(r, friendsimpleDto);
             r_List.add(dto);
         }
         return r_List;

--- a/favor/src/main/java/com/favor/favor/reminder/ReminderSimpleDto.java
+++ b/favor/src/main/java/com/favor/favor/reminder/ReminderSimpleDto.java
@@ -16,13 +16,24 @@ public class ReminderSimpleDto {
     private LocalDate reminderDate;
     private boolean isAlarmSet;
     private Long userNo;
+    private FriendSimpleDto friendSimpleDto;
 
+//    @Builder
+//    public ReminderSimpleDto(Reminder reminder){
+//        this.reminderNo = reminder.getReminderNo();
+//        this.reminderTitle = reminder.getReminderTitle();
+//        this.reminderDate = reminder.getReminderDate();
+//        this.isAlarmSet = reminder.getIsAlarmSet();
+//        this.userNo = reminder.getUser().getUserNo();
+//        this.friendSimpleDto = null;
+//    }
     @Builder
-    public ReminderSimpleDto(Reminder reminder){
+    public ReminderSimpleDto(Reminder reminder, FriendSimpleDto dto){
         this.reminderNo = reminder.getReminderNo();
         this.reminderTitle = reminder.getReminderTitle();
         this.reminderDate = reminder.getReminderDate();
         this.isAlarmSet = reminder.getIsAlarmSet();
         this.userNo = reminder.getUser().getUserNo();
+        this.friendSimpleDto = dto;
     }
 }


### PR DESCRIPTION
## 📋 이슈 번호
- close #77 

## 🛠 구현 사항
- 친구 식별자 입력받지 않아도 리마인더 생성 가능
- 친구 식별자 입력 시 FriendSimpleDto 제공

| 친구 식별자 X | 친구 식별자 O | 
| :---: | :---: |
| ![20231116005105](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/0fa295ec-17ba-4f50-bba8-f32c56ae6a9a) | ![20231116005059](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/cefea1ed-8744-4054-952a-77e0ed944923) | 
| ![20231116005112](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/ee7101ad-831f-425b-af01-ff0b19a8b68e) | ![20231116005052](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/e125e3c0-9e66-4ad2-92cb-ebbdc74a1a1e) | 

## 📚 기타
- 리마인더 생성 url 변경
  /reminders/new/{friendNo} -> /reminders/new
