### PR TITLE
[Fix] 회원 친구목록 조회 시 잘못된 정보 불러오는 문제

### DIFF
--- a/favor/src/main/java/com/favor/favor/user/User.java
+++ b/favor/src/main/java/com/favor/favor/user/User.java
@@ -1,6 +1,5 @@
 package com.favor.favor.user;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.favor.favor.anniversary.Anniversary;
 import com.favor.favor.anniversary.AnniversaryResponseDto;
 import com.favor.favor.common.enums.Favor;
@@ -34,32 +33,13 @@ public class User extends TimeStamped implements UserDetails {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userNo;
     private String email;
-
     private String password;
-    public void setPassword(String password){ this.password = password; }
-
     private String userId;
-    public void setUserId(String userId){
-        this.userId = userId;
-    }
-
     private String name;
-    public void setName(String name) {
-        this.name = name;
-    }
-
 
     @Builder.Default
     @ElementCollection
     private List<Integer> favorList = new ArrayList<>();
-    @Transactional
-    public void setFavorList(List<Favor> favorList) {
-        ArrayList<Integer> favorTypeList = new ArrayList<>();
-        for(Favor favor : favorList){
-            favorTypeList.add(favor.getType());
-        }
-        this.favorList = favorTypeList;
-    }
 
     @Builder.Default
     @OneToMany(mappedBy = "user", orphanRemoval = true)
@@ -79,17 +59,34 @@ public class User extends TimeStamped implements UserDetails {
 
     @OneToOne(cascade = CascadeType.ALL)
     private UserPhoto userProfilePhoto;
-    public void setUserProfilePhoto(UserPhoto userPhoto) {
-        this.userProfilePhoto = userPhoto;
-    }
 
     @OneToOne(cascade = CascadeType.ALL)
     private UserPhoto userBackgroundPhoto;
-    public void setUserBackgroundPhoto(UserPhoto userPhoto) {
-        this.userBackgroundPhoto = userPhoto;
-    }
 
     private Role role;
+
+
+    public void updatePassword(String password){ this.password = password; }
+    public void updateUserId(String userId){
+        this.userId = userId;
+    }
+    public void updateName(String name) {
+        this.name = name;
+    }
+    @Transactional
+    public void updateFavorList(List<Favor> favorList) {
+        ArrayList<Integer> favorTypeList = new ArrayList<>();
+        for(Favor favor : favorList){
+            favorTypeList.add(favor.getType());
+        }
+        this.favorList = favorTypeList;
+    }
+    public void updateUserProfilePhoto(UserPhoto userPhoto) {
+        this.userProfilePhoto = userPhoto;
+    }
+    public void updateUserBackgroundPhoto(UserPhoto userPhoto) {
+        this.userBackgroundPhoto = userPhoto;
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {return null;}

--- a/favor/src/main/java/com/favor/favor/user/UserPhotoService.java
+++ b/favor/src/main/java/com/favor/favor/user/UserPhotoService.java
@@ -10,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.net.URL;
-import java.util.Optional;
 import java.util.UUID;
 
 import static com.favor.favor.exception.ExceptionCode.SERVER_ERROR;
@@ -45,7 +44,7 @@ public class UserPhotoService {
             throw new CustomException(e, SERVER_ERROR);
         }
 
-        user.setUserProfilePhoto(userPhoto);
+        user.updateUserProfilePhoto(userPhoto);
         return userRepository.save(user);
     }
 
@@ -60,7 +59,7 @@ public class UserPhotoService {
 
         User user = userService.findUserByUserNo(userNo);
         String fileName = extractProfilePhotoFileName(user);
-        user.setUserProfilePhoto(null);
+        user.updateUserProfilePhoto(null);
         photoService.deleteFileFromS3(fileName);
     }
 
@@ -86,7 +85,7 @@ public class UserPhotoService {
             throw new CustomException(e, SERVER_ERROR);
         }
 
-        user.setUserBackgroundPhoto(userPhoto);
+        user.updateUserBackgroundPhoto(userPhoto);
         return userRepository.save(user);
     }
 
@@ -101,7 +100,7 @@ public class UserPhotoService {
 
         User user = userService.findUserByUserNo(userNo);
         String fileName = extractBackgroundPhotoFileName(user);
-        user.setUserBackgroundPhoto(null);
+        user.updateUserBackgroundPhoto(null);
         photoService.deleteFileFromS3(fileName);
     }
 

--- a/favor/src/main/java/com/favor/favor/user/UserService.java
+++ b/favor/src/main/java/com/favor/favor/user/UserService.java
@@ -25,7 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.favor.favor.exception.ExceptionCode.*;
@@ -61,8 +60,8 @@ public class UserService {
     public UserResponseDto createProfile(ProfileDto profileDto, Long userNo) {
         User user = findUserByUserNo(userNo);
 
-        user.setName(profileDto.getName());
-        user.setUserId(profileDto.getUserId());
+        user.updateName(profileDto.getName());
+        user.updateUserId(profileDto.getUserId());
         save(user);
 
         return user.toDto(user, readReminderList(user.getUserNo()), readFriendList(user.getUserNo()), readFavorList(user.getUserNo()), readAnniversaryList(user.getUserNo()), getGiftInfo(user.getUserNo()));
@@ -99,14 +98,22 @@ public class UserService {
 
     @Transactional
     public UserResponseDto updateUser(Long userNo, UserUpdateRequestDto userUpdateRequestDto){
-
+        //user 존재여부 확인
         isExistingUserNo(userNo);
-        isExistingUserId(userUpdateRequestDto.getUserId());
 
+        //user 의 기존 닉네임 확인
         User user = findUserByUserNo(userNo);
-        user.setName(userUpdateRequestDto.getName());
-        user.setUserId(userUpdateRequestDto.getUserId());
-        user.setFavorList(userUpdateRequestDto.getFavorList());
+        String beforeUserId = user.getUserId();
+        String newUserId = userUpdateRequestDto.getUserId();
+
+        //닉네임 변경 시 중복 체크
+        if(!beforeUserId.equals(newUserId)){
+            isExistingUserId(userUpdateRequestDto.getUserId());
+        }
+
+        user.updateName(userUpdateRequestDto.getName());
+        user.updateUserId(userUpdateRequestDto.getUserId());
+        user.updateFavorList(userUpdateRequestDto.getFavorList());
         save(user);
 
         return user.toDto(user, readReminderList(user.getUserNo()), readFriendList(user.getUserNo()), readFavorList(user.getUserNo()), readAnniversaryList(user.getUserNo()), getGiftInfo(user.getUserNo()));
@@ -121,7 +128,7 @@ public class UserService {
     @Transactional
     public UserResponseDto updatePassword(String email, String password){
         User user = findUserByEmail(email);
-        user.setPassword(passwordEncoder.encode(password));
+        user.updatePassword(passwordEncoder.encode(password));
         save(user);
 
         return user.toDto(user, readReminderList(user.getUserNo()), readFriendList(user.getUserNo()), readFavorList(user.getUserNo()), readAnniversaryList(user.getUserNo()), getGiftInfo(user.getUserNo()));


### PR DESCRIPTION
## 📋 이슈 번호
- close #95 

## 🛠 구현 사항
- User Setter update{필드명}으로 변경
    - 위치 조정 (필드 - 생성자 - 메소드)
- 유저 수정시, 닉네임 변경 시에만 중복 체크 실행


## 📚 기타
|  | 수정 전 | 수정 후 | 
| :---: | :---: | :---: |
| 요청 | ![20231225075052](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/c057e814-8a5f-4fd0-9b90-26da62d2244d) | ![20231225075052](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/ca592f74-41b3-4020-9839-a9680c2bc6fa) | 
| 응답 | ![20231225075105](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/a801c8f6-29e5-4b07-b2e2-d719f00d1130) | ![20231225074939](https://github.com/Favor-Gift-Reminder/Favor-Server/assets/114793764/0a3f75f1-aef2-4e18-ae6d-32202dd5acc3) | 